### PR TITLE
Support external layer + Delete source folder when using custom layer + Fix multiple functions + Lower redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Storing credentials as a Github secret is strongly recommended.
     Same as above if you need more layers.
 - `custom_layer_4_arn`
     Same as above if you need more layers.
+- `public_layer_1_arn`
+    The ARN of an external public Lambda layer in case you need one (e.g. https://github.com/keithrozario/Klayers).
+- `public_layer_2_arn`
+    Same as above if you need more layers.
+- `public_layer_3_arn`
+    Same as above if you need more layers.
+- `public_layer_4_arn`
+    Same as above if you need more layers.
 - `lambda_function_names`
     The Lambda function names comma separated.
 - `aws_region`

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,8 @@ inputs:
     description: the path to the code for custom layer 4
   custom_layer_4_arn:
     description: the ARN for custom layer 4
+  public_layer_1_arn:
+    description: the ARN for public layer 4
   lambda_function_names:
     description: The Lambda function names (comma-separated if you have multiple). Check the AWS docs/readme for examples.
     required: true
@@ -47,6 +49,7 @@ runs:
     - ${{ inputs.custom_layer_3_arn }}
     - ${{ inputs.custom_layer_4_path }}
     - ${{ inputs.custom_layer_4_arn }}
+    - ${{ inputs.public_layer_1_arn }}
 branding:
   icon: 'cloud-lightning'
   color: 'white'

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,12 @@ inputs:
   custom_layer_4_arn:
     description: the ARN for custom layer 4
   public_layer_1_arn:
+    description: the ARN for public layer 1
+  public_layer_2_arn:
+    description: the ARN for public layer 2
+  public_layer_3_arn:
+    description: the ARN for public layer 3
+  public_layer_4_arn:
     description: the ARN for public layer 4
   lambda_function_names:
     description: The Lambda function names (comma-separated if you have multiple). Check the AWS docs/readme for examples.
@@ -50,6 +56,9 @@ runs:
     - ${{ inputs.custom_layer_4_path }}
     - ${{ inputs.custom_layer_4_arn }}
     - ${{ inputs.public_layer_1_arn }}
+    - ${{ inputs.public_layer_2_arn }}
+    - ${{ inputs.public_layer_3_arn }}
+    - ${{ inputs.public_layer_4_arn }}
 branding:
   icon: 'cloud-lightning'
   color: 'white'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,7 @@ publish_custom_layers(){
     ALL_LAYERS_ARN_VERSION+=" ${INPUT_CUSTOM_LAYER_1_ARN}:${CUSTOM_LAYER_1_VERSION}"
     rm -rf python
     rm custom_layer_1.zip
+    rm -rf ${INPUT_CUSTOM_LAYER_1_PATH}
   fi
 
   if [ -z ${INPUT_CUSTOM_LAYER_2_PATH} ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,6 +114,27 @@ publish_public_layers(){
     echo "Publishing public layer 1"
     ALL_LAYERS_ARN_VERSION+=" ${INPUT_PUBLIC_LAYER_1_ARN}"
   fi
+
+  if [ -z ${INPUT_PUBLIC_LAYER_2_ARN} ]; then
+    echo "public_layer_1_arn is not set"
+  else
+    echo "Publishing public layer 1"
+    ALL_LAYERS_ARN_VERSION+=" ${INPUT_PUBLIC_LAYER_2_ARN}"
+  fi
+
+  if [ -z ${INPUT_PUBLIC_LAYER_3_ARN} ]; then
+    echo "public_layer_1_arn is not set"
+  else
+    echo "Publishing public layer 1"
+    ALL_LAYERS_ARN_VERSION+=" ${INPUT_PUBLIC_LAYER_3_ARN}"
+  fi
+
+  if [ -z ${INPUT_PUBLIC_LAYER_4_ARN} ]; then
+    echo "public_layer_1_arn is not set"
+  else
+    echo "Publishing public layer 1"
+    ALL_LAYERS_ARN_VERSION+=" ${INPUT_PUBLIC_LAYER_4_ARN}"
+  fi
 }
 
 publish_function(){

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,7 @@ publish_custom_layers(){
     ALL_LAYERS_ARN_VERSION+=" ${INPUT_CUSTOM_LAYER_2_ARN}:${CUSTOM_LAYER_2_VERSION}"
     rm -rf python
     rm custom_layer_2.zip
+    rm -rf ${INPUT_CUSTOM_LAYER_2_PATH}
   fi
 
   if [ -z ${INPUT_CUSTOM_LAYER_3_PATH} ]; then
@@ -84,6 +85,7 @@ publish_custom_layers(){
     ALL_LAYERS_ARN_VERSION+=" ${INPUT_CUSTOM_LAYER_3_ARN}:${CUSTOM_LAYER_3_VERSION}"
     rm -rf python
     rm custom_layer_3.zip
+    rm -rf ${INPUT_CUSTOM_LAYER_3_PATH}
   fi
 
   if [ -z ${INPUT_CUSTOM_LAYER_4_PATH} ]; then
@@ -105,6 +107,7 @@ publish_custom_layers(){
     ALL_LAYERS_ARN_VERSION+=" ${INPUT_CUSTOM_LAYER_4_ARN}:${CUSTOM_LAYER_4_VERSION}"
     rm -rf python
     rm custom_layer_4.zip
+    rm -rf ${INPUT_CUSTOM_LAYER_4_PATH}
   fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,6 +107,15 @@ publish_custom_layers(){
   fi
 }
 
+publish_public_layers(){
+  if [ -z ${INPUT_PUBLIC_LAYER_1_ARN} ]; then
+    echo "public_layer_1_arn is not set"
+  else
+    echo "Publishing public layer 1"
+    ALL_LAYERS_ARN_VERSION+=" ${INPUT_PUBLIC_LAYER_1_ARN}"
+  fi
+}
+
 publish_function(){
   echo "Deploying the code for ${1}"
   cd "${1}"
@@ -126,6 +135,7 @@ deploy_lambda_function(){
   configure_aws_credentials
   publish_pip_layer
   publish_custom_layers
+  publish_public_layers
 
   functionNames=(${INPUT_LAMBDA_FUNCTION_NAMES//,/ })
   for name in ${functionNames[@]}; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -141,14 +141,14 @@ publish_public_layers(){
   fi
 }
 
-publish_function(){
-  echo "Deploying the code for ${1}"
-  # cd "${1}"
-  zip -r code.zip .
-  aws lambda update-function-code --function-name "${1}" --zip-file fileb://code.zip
-  rm code.zip
-  # cd ..
-}
+# publish_function(){
+#   echo "Deploying the code for ${1}"
+#   # cd "${1}"
+#   zip -r code.zip .
+#   aws lambda update-function-code --function-name "${1}" --zip-file fileb://code.zip
+#   rm code.zip
+#   # cd ..
+# }
 
 update_function_layers(){
   echo "Adding pip layer and custom layers to ${1}"
@@ -163,10 +163,14 @@ deploy_lambda_function(){
   publish_public_layers
 
   functionNames=(${INPUT_LAMBDA_FUNCTION_NAMES//,/ })
+  zip -r code.zip .
   for name in ${functionNames[@]}; do
-    publish_function $name
+    echo "Deploying the code for ${1}"
+    aws lambda update-function-code --function-name "${1}" --zip-file fileb://code.zip
+    # publish_function $name
     update_function_layers $name
   done
+  rm code.zip
 }
 
 deploy_lambda_function

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -143,11 +143,11 @@ publish_public_layers(){
 
 publish_function(){
   echo "Deploying the code for ${1}"
-  cd "${1}"
+  # cd "${1}"
   zip -r code.zip .
   aws lambda update-function-code --function-name "${1}" --zip-file fileb://code.zip
   rm code.zip
-  cd ..
+  # cd ..
 }
 
 update_function_layers(){


### PR DESCRIPTION
Support for external layer (e.g. Klayers)
- I added 4 possible "public_layer_X_arn" input variables.
- Those allow the script to add external / public layer to the target functions.
- I required those in order to load "Klayers" dependencies: https://github.com/keithrozario/Klayers/tree/master/deployments/python3.8/arns

Delete custom_layer source folder after layer creation
- When using a "custom_layer", the script picks a source folder and create a layer out of it.
- As the source folder has now been made available as a new customer layer, I added the deletion of this source folder in order to avoid code redundancy: "rm -rf ${INPUT_CUSTOM_LAYER_4_PATH}" on each custom_layer_X_path function.

Fix code for multiple functions
- During my test, the multiple function code was not working properly. There was no "directory" named after the function in which the script shall enter. I removed therefore the "cd "${1}"" and "cd .." on function 'publish_function()'

Lower operation redundancy
- The function "publish_function()" was finally completely removed so that the zip "code.zip" is only created and deleted once and not each time for each target function.